### PR TITLE
Silently fail if element is not found

### DIFF
--- a/lib/xmpr.rb
+++ b/lib/xmpr.rb
@@ -100,8 +100,6 @@ module XMPR
         alt_value(alt_element, lang: lang)
       elsif array_element = element.xpath("./rdf:Bag | ./rdf:Seq", NAMESPACES).first
         array_value(array_element)
-      else
-        raise "Don't know how to handle:\n#{element}"
       end
     end
 


### PR DESCRIPTION
If you call to_hash on XMP data that has an unexpected value like in the example screenshot it will fail and not return any XML values.

<img width="1105" alt="Screen Shot 2019-11-13 at 5 41 30 pm" src="https://user-images.githubusercontent.com/501033/68741164-d932a200-063c-11ea-9203-8ac8e135ccb0.png">

I propose we remove this exception and return the values that are correctly parsed anyway so they can still be used.