### PR TITLE
Allow Ruby 3.0 and above

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on: [ push, pull_request ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version: ['2.6', '2.7', '3.0', '3.1']
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+
+      - run: bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
-  - 2.5
-before_install: gem install bundler

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # XMP Reader
 
-[![Build Status](https://travis-ci.org/sj26/xmpr?branch=master)](https://travis-ci.org/sj26/xmpr)
-
 XMP Reader in Ruby. Parse XMP data extracted from an image into rich data types.
 
 ## Usage

--- a/xmpr.gemspec
+++ b/xmpr.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/sj26/xmpr"
   spec.license = "MIT"
 
-  spec.required_ruby_version = "~> 2.1"
+  spec.required_ruby_version = ">= 2.1"
 
   spec.files = Dir["README.md", "LICENSE", "lib/**/*"]
   spec.test_files = Dir["test/**/*"]


### PR DESCRIPTION
### Context

It'd be great to use this gem on Ruby 3. However, the version restriction in the gemspec doesn't allow this.

### Change

- Migrate CI from TravisCI to GitHub Actions, and run the test suite on Ruby 2.6, 2.7, 3.0, and 3.1.
- Relax the gemspec constraint to allow Ruby 3 and above.